### PR TITLE
Remove werror compiler flag from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} \
                     -pedantic-errors \
                     -Wall \
                     -Wextra \
-                    -Werror \
                     -Wundef \
                     -Wshadow \
                     -Wwrite-strings \


### PR DESCRIPTION
Allow compilation with warnings, I've ran into issues while compiling on my platform.